### PR TITLE
fix: Adjust update service and timer

### DIFF
--- a/files/usr/lib/systemd/user/ublue-update.service
+++ b/files/usr/lib/systemd/user/ublue-update.service
@@ -1,9 +1,6 @@
-
 [Unit]
 Description=auto-update oneshot service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ublue-update
-Restart=on-failure
-RestartSec=15min

--- a/files/usr/lib/systemd/user/ublue-update.timer
+++ b/files/usr/lib/systemd/user/ublue-update.timer
@@ -3,8 +3,9 @@ Description=auto update system timer for uBlue
 Wants=network-online.target
 
 [Timer]
-OnBootSec=1h
-OnUnitInactiveSec=1d
+OnBootSec=15min
+OnUnitInactiveSec=6h
+Persistant=true
 
 [Install]
 WantedBy=timers.target

--- a/files/usr/lib/systemd/user/ublue-update.timer
+++ b/files/usr/lib/systemd/user/ublue-update.timer
@@ -5,7 +5,7 @@ Wants=network-online.target
 [Timer]
 OnBootSec=15min
 OnUnitInactiveSec=6h
-Persistant=true
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
ublue-update can inform systemd that it failed for a number of reasons including checks not passing or an update simply not being available at that time. Currently the service is bugged in that if a check fails, it will run again 15 minutes later, adding additional complications. This defeats the point of having checks to begin with as it introduces added overhead. Additionally, when an update actually is available, we can now allow the user to override the checks and update anyway, making this something that actually gets in the way. If consecutive update checks fail, the user may be constantly bombarded with notifications saying that an update is available, even if one isn't

This commit addresses the situation. Updates will now run 15 minutes after boot instead of one hour later, providing a higher chance that the system may actually be able to update. After this, ublue-update will run in 6 hour intervals. The overhead here is fairly minimal and the checks should be adequate enough to ensure that updates do not interfere with the user

Additionally, the timer is now persistant. Meaning, if the timer was missed for whatever reason, ublue-update will immediately run as soon as it is able to make up for that