### PR TITLE
feat: remove dependency on notify2 and replace with simple in-house module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 *.**.pyc
 *.pyc
+*.builder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ classifiers = [
 ]
 dependencies = [
     "notify2",
-    "psutil"
+    "psutil",
+    "pygobject",
+    "dbus-python"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ license = {text = "Apache-2"}
 classifiers = [
 ]
 dependencies = [
-    "notify2",
     "psutil",
     "pygobject",
     "dbus-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "psutil",
     "pygobject",
-    "dbus-python"
+    "dbus-python",
 ]
 dynamic = ["version"]
 

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -138,7 +138,8 @@ log = logging.getLogger(__name__)
 
 notification_manager = NotificationManager("Universal Blue Updater")
 
-#if dbus_notify:
+# if dbus_notify:
+
 
 def main():
 

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -6,7 +6,7 @@ import subprocess
 import logging
 import tomllib
 import argparse
-from notification_manager import NotificationManager
+from ublue_update.notification_manager import NotificationManager
 from gi.repository import GLib
 
 def check_cpu_load():

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -8,6 +8,7 @@ import logging
 import tomllib
 import argparse
 from ublue_update.notification_manager import NotificationManager
+from gi.repository import GLib
 
 
 def check_cpu_load():
@@ -123,11 +124,6 @@ def run_updates():
                             f"Error in update script: {file}, check logs for more info",
                             3,
                         )
-                        # notify2.Notification(
-                        #    "System Updater",
-                        #    f"Error in update script: {file}, check logs for more info",
-                        #    "notification-message-im",
-                        # ).show()
             else:
                 log.info(f"could not execute file {full_path}")
 

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -7,6 +7,7 @@ import tomllib
 import argparse
 from ublue_update.notification_manager import NotificationManager
 
+
 def check_cpu_load():
     # get load average percentage in last 5 minutes:
     # https://psutil.readthedocs.io/en/latest/index.html?highlight=getloadavg
@@ -114,12 +115,10 @@ def run_updates():
                     log.info(f"{full_path} returned error code: {out.returncode}")
                     log.info("Program output: \n {out.stdout}")
                     if dbus_notify:
-                        notification_manager.notify(
-                            0,
+                        notification_manager.notification(
                             "System Updater",
                             f"Error in update script: {file}, check logs for more info",
-                            3,
-                        )
+                        ).show(5)
             else:
                 log.info(f"could not execute file {full_path}")
 
@@ -137,9 +136,9 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
+notification_manager = NotificationManager("Universal Blue Updater")
 
-if dbus_notify:
-    notification_manager = NotificationManager("Universal Blue Updater")
+#if dbus_notify:
 
 def main():
 
@@ -162,22 +161,18 @@ def main():
     # system checks passed
     log.info("System passed all update checks")
     if dbus_notify:
-        notification_manager.notify(
-            0,
+        notification_manager.notification(
             "System Updater",
             "System passed checks, updating ...",
-            3,
-        )
+        ).show(5)
 
     if args.check:
         exit(0)
 
     run_updates()
     if dbus_notify:
-        notification_manager.notify(
-            0,
+        notification_manager.notification(
             "System Updater",
             "System update complete, reboot for changes to take effect",
-            3,
-        )
+        ).show(5)
     log.info("System update complete")

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -1,13 +1,14 @@
 import psutil
-#import notify2
+
 import dbus
+from dbus.mainloop.glib import DBusGMainLoop
 import os
 import subprocess
 import logging
 import tomllib
 import argparse
 from ublue_update.notification_manager import NotificationManager
-from gi.repository import GLib
+
 
 def check_cpu_load():
     # get load average percentage in last 5 minutes:
@@ -122,11 +123,11 @@ def run_updates():
                             f"Error in update script: {file}, check logs for more info",
                             3,
                         )
-                        #notify2.Notification(
+                        # notify2.Notification(
                         #    "System Updater",
                         #    f"Error in update script: {file}, check logs for more info",
                         #    "notification-message-im",
-                        #).show()
+                        # ).show()
             else:
                 log.info(f"could not execute file {full_path}")
 
@@ -145,11 +146,12 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 loop = GLib.MainLoop()
-dbus_loop = dbus.DBusGMainLoop()
+dbus_loop = DBusGMainLoop()
 bus = dbus.SessionBus(mainloop=dbus_loop)
 
 if dbus_notify:
     notification_manager = NotificationManager("Universal Blue Updater", bus)
+
 
 def main():
 
@@ -165,7 +167,6 @@ def main():
         "-c", "--check", action="store_true", help="run update checks and exit"
     )
     args = parser.parse_args()
-
 
     if not args.force:
         check_inhibitors()

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -1,15 +1,11 @@
 import psutil
 
-import dbus
-from dbus.mainloop.glib import DBusGMainLoop
 import os
 import subprocess
 import logging
 import tomllib
 import argparse
 from ublue_update.notification_manager import NotificationManager
-from gi.repository import GLib
-
 
 def check_cpu_load():
     # get load average percentage in last 5 minutes:
@@ -141,13 +137,9 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-loop = GLib.MainLoop()
-dbus_loop = DBusGMainLoop()
-bus = dbus.SessionBus(mainloop=dbus_loop)
 
 if dbus_notify:
-    notification_manager = NotificationManager("Universal Blue Updater", bus)
-
+    notification_manager = NotificationManager("Universal Blue Updater")
 
 def main():
 

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -9,7 +9,7 @@ class NotificationManager:
         path = "/" + item.replace(".", "/")
         self._app_name = app_name
         self._actions = []
-        self._notify_interface = dbus.Interface(self._bus.get_object(item, path), item)
+        self._notify_interface = dbus.Interface(bus.get_object(item, path), item)
         bus.add_signal_receiver(self._on_action, "ActionInvoked")
 
     def get_action_list(self, actions):

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -3,7 +3,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 
 
 class NotificationObject:
-    """Holds all of the data in a notification, stored in the notifications dict inside of notification_manager"""
+    """Holds all of the data in a notification"""
 
     def __init__(self, notification_manager, app_name, icon="", title="", body=""):
         self.notification_manager = notification_manager
@@ -60,7 +60,7 @@ class NotificationManager:
         self._actions.append(action)
 
     def _on_action(self, id, action_key):
-        notification = notifications.get(id)
+        notification = self.notifications.get(id)
         if notification:
             triggered_action = notification.actions.get(action_key)
             triggered_action["handler"]()

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -1,0 +1,43 @@
+import dbus
+
+class NotificationManager:
+    """Manages DBus notifications and action dispatching"""
+
+    def __init__(self, app_name, bus):
+        item = "org.freedesktop.Notifications"
+        path =  "/"+item.replace(".", "/")
+        self._app_name = app_name
+        self._actions = []
+        self._notify_interface = dbus.Interface(
+        bus.get_object(item, path),
+            item
+        )
+        bus.add_signal_receiver(self._on_action,"ActionInvoked")
+
+    def get_action_list(self, actions):
+        dbus_actions = []
+        for action in actions:
+            dbus_actions.append(action['key'])
+            dbus_actions.append(action['text'])
+        return dbus_actions
+
+    def add_action(self, action):
+        self._actions.append(action)
+
+    def _on_action(self, id, action_key):
+        triggered_action = [action for action in self._actions if action['key'] == action_key][0]
+        triggered_action['handler']()
+
+    def notify(self, id, title, body, timeout):
+        actions = self.get_action_list(self._actions)
+        self._notify_interface.Notify(
+            self._app_name,
+            id,
+            "weather-clear", # not sure what this is
+            title,
+            body,
+            actions,
+            { "urgency": 1 },
+            timeout * 1000
+        )
+

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -2,6 +2,40 @@ import dbus
 from dbus.mainloop.glib import DBusGMainLoop
 
 
+class NotificationObject:
+    """Holds all of the data in a notification, stored in the notifications dict inside of notification_manager"""
+
+    def __init__(self, notification_manager, app_name, icon="", title="", body=""):
+        self.notification_manager = notification_manager
+        self.app_name = app_name
+        self.id = 0
+        self.icon = icon
+        self.title = title
+        self.body = body
+        self.actions = {}
+        self.hints = {}
+
+    def add_action(self, key, text, handler):
+        self.actions.update({key: {"text": text, "handler": handler}})
+
+    def add_hint(self, hint):
+        self.hints.update(hint)
+
+    def show(self, timeout_sec):
+        actions = self.notification_manager.get_action_list(self.actions)
+        self.id = self.notification_manager.notify_interface.Notify(
+            self.app_name,
+            self.id,
+            self.icon,  # not sure what this is
+            self.title,
+            self.body,
+            actions,
+            self.hints,
+            timeout_sec * 1000,
+        )
+        self.notification_manager.notifications.update({self.id: self})
+
+
 class NotificationManager:
     """Manages DBus notifications and action dispatching"""
 
@@ -12,9 +46,8 @@ class NotificationManager:
         self._bus = dbus.SessionBus(mainloop=self.dbus_loop)
         self._bus.add_signal_receiver(self._on_action, "ActionInvoked")
         self._app_name = app_name
-        self._actions = []
-        self._notify_interface = dbus.Interface(self._bus.get_object(item, path), item)
-
+        self.notifications = {}
+        self.notify_interface = dbus.Interface(self._bus.get_object(item, path), item)
 
     def get_action_list(self, actions):
         dbus_actions = []
@@ -27,20 +60,10 @@ class NotificationManager:
         self._actions.append(action)
 
     def _on_action(self, id, action_key):
-        triggered_action = [
-            action for action in self._actions if action["key"] == action_key
-        ][0]
-        triggered_action["handler"]()
+        notification = notifications.get(id)
+        if notification:
+            triggered_action = notification.actions.get(action_key)
+            triggered_action["handler"]()
 
-    def notify(self, id, title, body, timeout):
-        actions = self.get_action_list(self._actions)
-        self._notify_interface.Notify(
-            self._app_name,
-            id,
-            "weather-clear",  # not sure what this is
-            title,
-            body,
-            actions,
-            {"urgency": 1},
-            timeout * 1000,
-        )
+    def notification(self, title, body, icon = ""):
+        return NotificationObject(self, self._app_name, icon, title, body)

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -65,5 +65,5 @@ class NotificationManager:
             triggered_action = notification.actions.get(action_key)
             triggered_action["handler"]()
 
-    def notification(self, title, body, icon = ""):
+    def notification(self, title, body, icon=""):
         return NotificationObject(self, self._app_name, icon, title, body)

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -1,43 +1,42 @@
 import dbus
 
+
 class NotificationManager:
     """Manages DBus notifications and action dispatching"""
 
     def __init__(self, app_name, bus):
         item = "org.freedesktop.Notifications"
-        path =  "/"+item.replace(".", "/")
+        path = "/" + item.replace(".", "/")
         self._app_name = app_name
         self._actions = []
-        self._notify_interface = dbus.Interface(
-        bus.get_object(item, path),
-            item
-        )
-        bus.add_signal_receiver(self._on_action,"ActionInvoked")
+        self._notify_interface = dbus.Interface(self._bus.get_object(item, path), item)
+        bus.add_signal_receiver(self._on_action, "ActionInvoked")
 
     def get_action_list(self, actions):
         dbus_actions = []
         for action in actions:
-            dbus_actions.append(action['key'])
-            dbus_actions.append(action['text'])
+            dbus_actions.append(action["key"])
+            dbus_actions.append(action["text"])
         return dbus_actions
 
     def add_action(self, action):
         self._actions.append(action)
 
     def _on_action(self, id, action_key):
-        triggered_action = [action for action in self._actions if action['key'] == action_key][0]
-        triggered_action['handler']()
+        triggered_action = [
+            action for action in self._actions if action["key"] == action_key
+        ][0]
+        triggered_action["handler"]()
 
     def notify(self, id, title, body, timeout):
         actions = self.get_action_list(self._actions)
         self._notify_interface.Notify(
             self._app_name,
             id,
-            "weather-clear", # not sure what this is
+            "weather-clear",  # not sure what this is
             title,
             body,
             actions,
-            { "urgency": 1 },
-            timeout * 1000
+            {"urgency": 1},
+            timeout * 1000,
         )
-

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -1,16 +1,20 @@
 import dbus
+from dbus.mainloop.glib import DBusGMainLoop
 
 
 class NotificationManager:
     """Manages DBus notifications and action dispatching"""
 
-    def __init__(self, app_name, bus):
+    def __init__(self, app_name):
         item = "org.freedesktop.Notifications"
         path = "/" + item.replace(".", "/")
+        self.dbus_loop = DBusGMainLoop()
+        self._bus = dbus.SessionBus(mainloop=self.dbus_loop)
+        self._bus.add_signal_receiver(self._on_action, "ActionInvoked")
         self._app_name = app_name
         self._actions = []
-        self._notify_interface = dbus.Interface(bus.get_object(item, path), item)
-        bus.add_signal_receiver(self._on_action, "ActionInvoked")
+        self._notify_interface = dbus.Interface(self._bus.get_object(item, path), item)
+
 
     def get_action_list(self, actions):
         dbus_actions = []

--- a/ublue-update.spec.rpkg
+++ b/ublue-update.spec.rpkg
@@ -13,8 +13,8 @@ VCS:        {{{ git_dir_vcs }}}
 # and returns its filename. The tarball will be used to build the rpm.
 Source:     {{{ git_dir_pack }}}
 
-BuildArch:      noarch
-Supplements:    rpm-ostree flatpak
+BuildArch:     noarch
+Supplements:   rpm-ostree flatpak
 BuildRequires: make
 BuildRequires: systemd-rpm-macros
 BuildRequires: black


### PR DESCRIPTION
- Removed all dependency on the deprecated notify2 library
- Added the notification_manager module
Things to consider:
- abstract all dbus and glib logic to notification_manager (initializing the bus, setting up main loop, etc)
- Add notification object? The idea would be to make adding actions easier and not force every notification to use the same actions, dunno how much this would complicate things