### PR TITLE
fix: use builder container file for release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: |
-            ./Containerfile
+            ./Containerfile.builder
           image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ needs.release-please.outputs.tag }}


### PR DESCRIPTION
This will allow us to push the rpm to the release created by release please