### PR TITLE
fix: fix program exiting telling user checks have failed when running from notification

### DIFF
--- a/Containerfile.builder
+++ b/Containerfile.builder
@@ -3,6 +3,7 @@ FROM registry.fedoraproject.org/fedora:latest AS builder
 ENV UBLUE_ROOT=/app/output
 
 WORKDIR /app 
+
 ADD . /app
 
 RUN dnf install \
@@ -21,3 +22,5 @@ RUN dnf install \
 FROM builder AS rpm
 
 RUN make build-rpm
+
+

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -12,17 +12,16 @@ from ublue_update.update_checks.system import system_update_check
 
 
 def ask_for_updates():
-    if dbus_notify:
-        update_notif = notification_manager.notification(
-            "System Updater",
-            "Update available, but system checks failed. Update now?",
-        )
-        update_notif.add_action(
-            "universal-blue-update-confirm",
-            "Confirm",
-            lambda: run_updates(),
-        )
-        update_notif.show(15)
+    update_notif = notification_manager.notification(
+        "System Updater",
+        "Update available, but system checks failed. Update now?",
+    )
+    update_notif.add_action(
+        "universal-blue-update-confirm",
+        "Confirm",
+        lambda: run_updates(),
+    )
+    update_notif.show(15)
 
 
 def check_for_updates(checks_failed: bool) -> bool:

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -180,8 +180,11 @@ log = logging.getLogger(__name__)
 
 notification_manager = None
 
-if dbus_notify:
+# Sometimes the system doesn't have a running dbus session or a notification daemon
+try:
     notification_manager = NotificationManager("Universal Blue Updater")
+except Exception:
+    dbus_notify = False
 
 
 def main():

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -1,5 +1,4 @@
 import psutil
-import sys
 import os
 import subprocess
 import logging
@@ -83,6 +82,7 @@ def hardware_inhibitor_checks_failed(
     # systemd will try to rerun the unit
     exception_log = "\n - ".join(failures)
     raise Exception(f"update failed to pass checks: \n - {exception_log}")
+
 
 def check_hardware_inhibitors() -> bool:
 

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -5,7 +5,6 @@ import subprocess
 import logging
 import tomllib
 import argparse
-import signal
 
 from ublue_update.notification_manager import NotificationManager
 from ublue_update.update_checks.system import system_update_check
@@ -87,6 +86,7 @@ def hardware_inhibitor_checks_failed(
         raise Exception(f"update failed to pass checks: \n - {exception_log}")
     sys.exit()
 
+
 def check_hardware_inhibitors() -> bool:
 
     hardware_inhibitors = [
@@ -166,6 +166,7 @@ def run_updates():
         ).show(5)
     log.info("System update complete")
 
+
 config, fallback_config = load_config()
 
 dbus_notify: bool = load_value("notify", "dbus_notify")
@@ -233,4 +234,3 @@ def main():
         ).show(5)
 
     run_updates()
-

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -79,13 +79,10 @@ def hardware_inhibitor_checks_failed(
     if check_for_updates(hardware_checks_failed) and dbus_ask_for_updates:
         log.info("Harware checks failed, but update is available")
         ask_for_updates()
-    else:
-        # notify systemd that the checks have failed,
-        # systemd will try to rerun the unit
-        exception_log = "\n - ".join(failures)
-        raise Exception(f"update failed to pass checks: \n - {exception_log}")
-    sys.exit()
-
+    # notify systemd that the checks have failed,
+    # systemd will try to rerun the unit
+    exception_log = "\n - ".join(failures)
+    raise Exception(f"update failed to pass checks: \n - {exception_log}")
 
 def check_hardware_inhibitors() -> bool:
 
@@ -165,6 +162,7 @@ def run_updates():
             "System update complete, reboot for changes to take effect",
         ).show(5)
     log.info("System update complete")
+    os._exit(0)
 
 
 config, fallback_config = load_config()
@@ -217,13 +215,13 @@ def main():
                 dbus_notify and not args.check,
             )
         if args.check:
-            sys.exit()
+            os._exit(0)
 
     if args.updatecheck:
         update_available = check_for_updates(False)
         if not update_available:
             raise Exception("Update not available")
-        sys.exit()
+        os._exit(0)
 
     # system checks passed
     log.info("System passed all update checks")

--- a/src/ublue_update/notification_manager.py
+++ b/src/ublue_update/notification_manager.py
@@ -49,8 +49,8 @@ class NotificationManager:
         self.dbus_loop = DBusGMainLoop()
         self.loop = GLib.MainLoop()
         self._bus = dbus.SessionBus(mainloop=self.dbus_loop)
-        self._bus.add_signal_receiver(self._on_action, "ActionInvoked")
-        self._bus.add_signal_receiver(self._on_closed, "NotificationClosed")
+        self._bus.add_signal_receiver(self._on_action, "ActionInvoked", item)
+        self._bus.add_signal_receiver(self._on_closed, "NotificationClosed", item)
         self._app_name = app_name
         self.notifications = {}
         self.notify_interface = dbus.Interface(self._bus.get_object(item, path), item)


### PR DESCRIPTION
This makes it so it only has an exit code of one when it doesn't ask the user for updates. If the user is prompted to accept an update and accepts, the program will exit with OK, otherwise it will throw the exception