### PR TITLE
fix: Check if the url already contains the protocol during update checks

### DIFF
--- a/src/ublue_update/update_checks/system.py
+++ b/src/ublue_update/update_checks/system.py
@@ -31,7 +31,10 @@ def system_update_check():
     tag = current_image[2]
 
     """Pull digest from latest image"""
-    latest_image = protocol + url + ":" + tag
+    if protocol in url:
+        latest_image = url + ":" + tag
+    else:
+        latest_image = protocol + url + ":" + tag
     latest_digest = skopeo_inspect(latest_image)
 
     """Compare current digest to latest digest"""


### PR DESCRIPTION
In some cases, the url may already contain the protocol. In such cases, we need to verify it's already there otherwise it is duplicated