### PR TITLE
fix: remove typo in arguments for notify-send

### DIFF
--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -18,7 +18,7 @@ def notify(title: str, body: str, actions: list = [], urgency: str = "normal"):
         body,
         "--app-name=Universal Blue Updater",
         "--icon=software-update-available-symbolic",
-        f"--urgency=${urgency}",
+        f"--urgency={urgency}",
     ]
     if actions != []:
         for action in actions:


### PR DESCRIPTION
This fixes dbus notifications, after accidentally breaking them in the previous PR