### PR TITLE
chore: add copr build so we are packaged in COPR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/akdev1l/copr-build:latest
+    if: github.event_name != 'pull_request'
     steps:
       - name: trigger copr build
         uses: akdev1l/copr-build@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 5 * * *'  # 5 am everyday
   workflow_dispatch:  
 env:
     IMAGE_NAME: ublue-update
@@ -105,3 +103,19 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"
+          
+  copr-build:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/akdev1l/copr-build:latest
+    steps:
+      - name: trigger copr build
+        uses: akdev1l/copr-build@main
+        id: copr-build
+        env:
+          COPR_API_TOKEN_CONFIG: ${{ secrets.UBLUE_COPR_API_TOKEN }}
+        with:
+          owner: ublue-os


### PR DESCRIPTION
This will make use of wip akdev1l/copr-build (I will fork this into ublue-os/copr-build when it is ready) to generate copr repo pointing to this github repo.

The copr repo build will be triggered by this action as well.

I have removed the scheduled 5 AM build because the application build does not really change that often (the dependencies get pulled in when RPM is installed so it will not install outdated dependencies)