### PR TITLE
fix: preserve unsigned image tag upon rebase

### DIFF
--- a/files/etc/ublue-update.d/system/00-system-update.sh
+++ b/files/etc/ublue-update.d/system/00-system-update.sh
@@ -5,7 +5,7 @@ check_for_rebase() {
     if [ -f "$IMAGE_REF_FILE" ]; then
 
         STATUS_COMMAND="rpm-ostree status --pending-exit-77 -b --json"
-        LOCAL_IMAGE_REF=$($STATUS_COMMAND | jq -r '.deployments[0]["container-image-reference"]')
+        LOCAL_IMAGE_REF=$($STATUS_COMMAND | jq -r '.deployments[0]["container-image-reference"]' | sed 's@ostree-unverified-registry:@ostree-unverified-image:docker://@g')
 
         if ! $STATUS_COMMAND >/dev/null || [[ "$LOCAL_IMAGE_REF" == "null" ]]; then
             # if jq failed to get the variable, or rpm-ostree had a nonzero exit code, return

--- a/files/etc/ublue-update.d/system/00-system-update.sh
+++ b/files/etc/ublue-update.d/system/00-system-update.sh
@@ -7,7 +7,7 @@ check_for_rebase() {
         STATUS_COMMAND="rpm-ostree status --pending-exit-77 -b --json"
         LOCAL_IMAGE_REF=$($STATUS_COMMAND | jq -r '.deployments[0]["container-image-reference"]')
 
-        if ! $STATUS_COMMAND >/dev/null || [[ "$LOCAL_IMAGE_REF" -eq "null" ]]; then
+        if ! $STATUS_COMMAND >/dev/null || [[ "$LOCAL_IMAGE_REF" == "null" ]]; then
             # if jq failed to get the variable, or rpm-ostree had a nonzero exit code, return
             return
         fi
@@ -20,10 +20,9 @@ check_for_rebase() {
         IMAGE_TAG=$(jq -r '."image-tag"' < "$IMAGE_REF_FILE")
 
         if [[ "$LOCAL_IMAGE_REF_UNTAGGED" != "$IMAGE_REF" ]]; then
-            if [[ "$LOCAL_IMAGE_PREFIX" -eq "ostree-unverified-image" ]]; then
+            if [[ "$LOCAL_IMAGE_PREFIX" == "ostree-unverified-image" ]]; then
                 # preserve image tags
                 IMAGE_TAG="$LOCAL_IMAGE_REF_TAG"
-
             fi
             /usr/bin/rpm-ostree rebase "$IMAGE_REF:$IMAGE_TAG"
             exit

--- a/files/etc/ublue-update.d/system/00-system-update.sh
+++ b/files/etc/ublue-update.d/system/00-system-update.sh
@@ -3,15 +3,28 @@
 check_for_rebase() {
     IMAGE_REF_FILE="$1"
     if [ -f "$IMAGE_REF_FILE" ]; then
-        LOCAL_IMAGE_REF=$(rpm-ostree status --pending-exit-77 -b --json | jq -r '.deployments[0]["container-image-reference"]')
-        if [[ "$LOCAL_IMAGE_REF" == "null" ]]; then
+
+        STATUS_COMMAND="rpm-ostree status --pending-exit-77 -b --json"
+        LOCAL_IMAGE_REF=$($STATUS_COMMAND | jq -r '.deployments[0]["container-image-reference"]')
+
+        if ! $STATUS_COMMAND >/dev/null || [[ "$LOCAL_IMAGE_REF" -eq "null" ]]; then
+            # if jq failed to get the variable, or rpm-ostree had a nonzero exit code, return
             return
         fi
+
+        LOCAL_IMAGE_PREFIX=$(echo "$LOCAL_IMAGE_REF" | awk -F ":" '{print $1}')
         LOCAL_IMAGE_REF_UNTAGGED=$(echo "$LOCAL_IMAGE_REF" | awk -F ":" '{print $1":"$2":"$3}')
+        LOCAL_IMAGE_REF_TAG=$(echo "$LOCAL_IMAGE_REF" | awk -F ":" '{print $4}')
+
         IMAGE_REF=$(jq -r '."image-ref"' < "$IMAGE_REF_FILE")
         IMAGE_TAG=$(jq -r '."image-tag"' < "$IMAGE_REF_FILE")
 
         if [[ "$LOCAL_IMAGE_REF_UNTAGGED" != "$IMAGE_REF" ]]; then
+            if [[ "$LOCAL_IMAGE_PREFIX" -eq "ostree-unverified-image" ]]; then
+                # preserve image tags
+                IMAGE_TAG="$LOCAL_IMAGE_REF_TAG"
+
+            fi
             /usr/bin/rpm-ostree rebase "$IMAGE_REF:$IMAGE_TAG"
             exit
         fi


### PR DESCRIPTION
this should hopefully rectify the rebasing woes. Just need to test it, hopefully this should remove the blockers needed to integrate with bluefin