### PR TITLE
chore: bump version

### DIFF
--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,6 +1,6 @@
 function ublue_update_version {
     if [ "$GITHUB_REF_NAME" = "" ]; then
-        echo "1.0.0+$(git rev-parse --short HEAD)"
+        echo "1.1.0+$(git rev-parse --short HEAD)"
     else
         echo "$GITHUB_REF_NAME" 
     fi


### PR DESCRIPTION
To be sure the latest build version is higher then all before, we can rule out if the package manager is picking an old version based on the version tag.

Can be merged when #84  is succesfully merged into main.