### PR TITLE
fix: offline iso update

### DIFF
--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,6 +1,6 @@
 function ublue_update_version {
     if [ "$GITHUB_REF_NAME" = "" ]; then
-        echo "1.1.0+$(git rev-parse --short HEAD)"
+        echo "1.1.1+$(git rev-parse --short HEAD)"
     else
         echo "$GITHUB_REF_NAME" 
     fi

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -167,7 +167,7 @@ def run_updates(system, system_update_available):
             )
             log.debug(out.stdout.decode("utf-8"))
         log.info("System update complete")
-        if pending_deployment_check() and system_update_available:
+        if pending_deployment_check() and system_update_available and dbus_notify:
             out = notify(
                 "System Updater",
                 "System update complete, pending changes will take effect after reboot. Reboot now?",

--- a/src/ublue_update/update_checks/system.py
+++ b/src/ublue_update/update_checks/system.py
@@ -35,6 +35,9 @@ def system_update_check():
     protocol = "docker://"
     url = current_image[1]
 
+    if url == "oci:/var/ublue-os/image":
+        return True
+
     """Add protocol if URL doesn't contain it"""
     if protocol not in url:
         url = protocol + url


### PR DESCRIPTION
Fixes #86 

This will always return True when we are on a offline installation which contains the oci variant `oci:/var/ublue-os/image`

Add another condition to verify we want to have a dbus notification
```
Traceback (most recent call last):
  File "/usr/bin/ublue-update", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/ublue_update/cli.py", line 255, in main
    run_updates(cli_args.system, system_update_available)
  File "/usr/lib/python3.11/site-packages/ublue_update/cli.py", line 177, in run_updates
    if "universal-blue-update-reboot" in out.stdout.decode("utf-8"):
                                         ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'stdout'
```

Bump the spec version with x.x.1