### PR TITLE
fix: be more carefull when to rebase

### DIFF
--- a/files/etc/ublue-update.d/system/00-system-update.py
+++ b/files/etc/ublue-update.d/system/00-system-update.py
@@ -42,6 +42,7 @@ def check_for_rebase():
             )  # replace shorthand
             .split(":")
         )
+         # if the same ref as image-info.json then skip rebase
         if current_image_ref[:-1] == default_image_ref:
             return False, ""
     except (JSONDecodeError, KeyError, IndexError):
@@ -50,7 +51,21 @@ def check_for_rebase():
         return False, ""
 
     image_tag = default_image_tag
-    try:  # preserve image tag when rebasing unsigned
+    try:
+        # if we are on an offline ISO installation
+        # rebase to image-info.json defaults
+        if current_image_ref[2] == "/var/ublue-os/image":
+            return (
+                True,
+                f"{default_image_ref[0]}:{default_image_ref[1]}:{default_image_ref[2]}:{default_image_tag}",
+            )
+
+        # if current installation doesn't match image-info.json
+        # skip rebase to be safe
+        if current_image_ref[2] != default_image_ref[2]:
+            return False, ""
+
+        # We want to rebase so preserve image tag when rebasing unsigned
         if current_image_ref[2] == default_image_ref[2]:
             image_tag = current_image_ref[3]
     except IndexError:

--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,6 +1,6 @@
 function ublue_update_version {
     if [ "$GITHUB_REF_NAME" = "" ]; then
-        echo "1.1.1+$(git rev-parse --short HEAD)"
+        echo "1.1.2+$(git rev-parse --short HEAD)"
     else
         echo "$GITHUB_REF_NAME" 
     fi


### PR DESCRIPTION
This PR contains changes to be more carefull when to actually rebase. It won't rebase forks or images if the image-info.json is not updated to match the fork. It does rebase installations when the offline ISO is used, or upstream installations with matching image-info.json.

### Test case 1
Fork of bluefin-dx, without updating meta information in image-info.json:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin-dx",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bluefin-dx:38
                   Digest: sha256:f67b3809fc5bedff126fb0c57e04ba8b45cf3e93ea06cb2bdc0a08f9f7926200
                  Version: 38.20231019.0 (2023-10-19T10:24:36Z)
```

### Result after running the script
Not rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bluefin-dx:38
                   Digest: sha256:f67b3809fc5bedff126fb0c57e04ba8b45cf3e93ea06cb2bdc0a08f9f7926200
                  Version: 38.20231019.0 (2023-10-19T10:24:36Z)
```

### Test case 2
Fork of bluefin, with updated meta information in image-info.json:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin",
  "image-flavor": "main",
  "image-vendor": "bobslept",
  "image-ref": "ostree-image-signed:docker://ghcr.io/bobslept/bluefin",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bluefin:38
                   Digest: sha256:7d5f398bfc8847a2a0c06da21db4e169d75564136d448bfc72601c3916371422
                  Version: 38.20231019.0 (2023-10-19T17:43:18Z)

```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/bobslept/bluefin:38
                   Digest: sha256:7d5f398bfc8847a2a0c06da21db4e169d75564136d448bfc72601c3916371422
                  Version: 38.20231019.0 (2023-10-19T17:43:18Z)

● ostree-unverified-registry:ghcr.io/bobslept/bluefin:38
                   Digest: sha256:7d5f398bfc8847a2a0c06da21db4e169d75564136d448bfc72601c3916371422
                  Version: 38.20231019.0 (2023-10-19T17:43:18Z)
```
### Test case 3
Custom Containerfile based on `FROM ghcr.io/ublue-os/bluefin${IMAGE_TYPE}:${FEDORA_MAJOR_VERSION}`, without updated meta information in image-info.json:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bigpodsb/alpha-main:38
                   Digest: sha256:d52e5a4a1a35666c170ed2cd5b9d46f96f286dceab5ca24ab13baaf6c2f7cc1f
                  Version: 38.20231019.0 (2023-10-19T18:33:20Z)
```
### Result after running the script
Not rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bigpodsb/alpha-main:38
                   Digest: sha256:d52e5a4a1a35666c170ed2cd5b9d46f96f286dceab5ca24ab13baaf6c2f7cc1f
                  Version: 38.20231019.0 (2023-10-19T18:33:20Z)
```
### Test case 4
Custom Containerfile based on `FROM ghcr.io/ublue-os/bluefin${IMAGE_TYPE}:${FEDORA_MAJOR_VERSION}`, with updated meta information in image-info.json:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bigpodsb-alpha",
  "image-flavor": "",
  "image-vendor": "bobslept",
  "image-ref": "ostree-image-signed:docker://ghcr.io/bobslept/bigpodsb/alpha-main",
  "image-tag":"latest",
  "base-image-name": "ghcr.io/ublue-os/bluefin:",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/bobslept/bigpodsb/alpha-main:38
                   Digest: sha256:ed4c117ac27a24a7e3b03c17a94e53b60d97fbb3cac49950c31e85f8b5ed385e
                  Version: 38.20231019.0 (2023-10-19T18:51:02Z)
```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/bobslept/bigpodsb/alpha-main:38
                   Digest: sha256:ed4c117ac27a24a7e3b03c17a94e53b60d97fbb3cac49950c31e85f8b5ed385e
                  Version: 38.20231019.0 (2023-10-19T18:51:02Z)
```
### Test case 5
Installation of `ostree-unverified-registry:ghcr.io/ublue-os/bluefin-framework:38` via rebase (project build in bluefin, based of framework repo):

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin-framework",
  "image-flavor": "framework",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-framework",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/ublue-os/bluefin-framework:38
                   Digest: sha256:5e4cccbc8835a5fe60b61d0a4546893d3f3e3a9f64ffeb42b5bf0cd08f68053c
                Timestamp: 2023-10-19T18:37:35Z
```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-framework:38
                   Digest: sha256:5e4cccbc8835a5fe60b61d0a4546893d3f3e3a9f64ffeb42b5bf0cd08f68053c
                Timestamp: 2023-10-19T18:37:35Z
```
### Test case 6
Online ISO installation of `bluefin:38` via https://github.com/ublue-os/bluefin/releases/download/v1.0.0/bluefin-38.iso:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-image:docker://ghcr.io/ublue-os/bluefin:38
                   Digest: sha256:0d75f1629b1d0bc5432567661d7175b769d95d3f1d9e24bedddeb1d1502e3ebd
                  Version: 38.20231019.0 (2023-10-19T19:30:46Z)

```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin:38
                   Digest: sha256:0d75f1629b1d0bc5432567661d7175b769d95d3f1d9e24bedddeb1d1502e3ebd
                  Version: 38.20231019.0 (2023-10-19T19:30:46Z)
```

### Test case 7
Online ISO installation of `bluefin-dx:38` via https://github.com/ublue-os/main/releases/download/v1.10.0/universalblue-38-x86_64-20231011.iso:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin-dx",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-image:docker://ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:a1a8cd1058e447180a8d90d2ad37eaf30e6b073a2b8ea3b51f363b4a4adc00ef
                  Version: 38.20231019.0 (2023-10-19T19:45:19Z)


```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:a1a8cd1058e447180a8d90d2ad37eaf30e6b073a2b8ea3b51f363b4a4adc00ef
                  Version: 38.20231019.0 (2023-10-19T19:45:19Z)
```

### Test case 8
Offline installation of `bluefin:38` via ISO created with mkociso:

```
cat /usr/share/ublue-os/image-info.json 
{
  "image-name": "bluefin",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/bluefin",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-image:oci:/var/ublue-os/image
                   Digest: sha256:5f9386a607596fa6a499531a1e745708cc80b6a6d692b36fb9e66937b7f5d8ff
                  Version: 38.20231017.0 (2023-10-19T19:54:25Z)
```
### Result after running the script
Rebased
```
rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin:latest
                   Digest: sha256:0d75f1629b1d0bc5432567661d7175b769d95d3f1d9e24bedddeb1d1502e3ebd
                  Version: 38.20231019.0 (2023-10-19T18:35:53Z)
                     Diff: 21 upgraded, 7 removed, 7 added
```

