### PR TITLE
fix: min_battery_percent = 0 now works to "skip" battery check

### DIFF
--- a/src/ublue_update/update_inhibitors/hardware.py
+++ b/src/ublue_update/update_inhibitors/hardware.py
@@ -29,7 +29,7 @@ def check_battery_status() -> dict:
     battery_pass: bool = True
     if battery_status is not None:
         battery_pass = (
-            battery_status.percent > min_battery_percent or battery_status.power_plugged
+            battery_status.percent >= min_battery_percent or battery_status.power_plugged
         )
     return {
         "passed": battery_pass,


### PR DESCRIPTION
Until giampaolo/psutil#2305 is merged, machines with no battery can fail the check if they have external devices that are reporting battery levels (#79).

In my case, my wireless Logitech headphones report 0% battery if the dongle is plugged in but the headphones are off, and even setting `min_battery_percent = 0` in the config doesn't work, because 0 is not greater than 0.

This little tweak just makes it so 0 values pass the check correctly.

Could make a special case for `min_battery_percent = 0` to skip the check entirely instead, not sure which would be more preferred.