### PR TITLE
chore: version bump

### DIFF
--- a/rpkg.macros
+++ b/rpkg.macros
@@ -1,6 +1,6 @@
 function ublue_update_version {
     if [ "$GITHUB_REF_NAME" = "" ]; then
-        echo "1.1.2+$(git rev-parse --short HEAD)"
+        echo "1.1.3+$(git rev-parse --short HEAD)"
     else
         echo "$GITHUB_REF_NAME" 
     fi


### PR DESCRIPTION
New commits are merged but the version wasn't bumped. Version currently being installed is `ublue-update-1.1.2+427912c-1.fc38.noarch` which is a 13 day old build instead of the new one with merged changes.

- https://github.com/ublue-os/ublue-update/pull/89
- https://github.com/ublue-os/ublue-update/pull/91

@EyeCantCU 