### PR TITLE
Add network_not_metered and custom check scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,26 +88,36 @@ See [`topgrade`](https://github.com/topgrade-rs/topgrade)'s GitHub for configuri
 
 ## Location
 
-### Valid config paths (in order of priority):
+### Valid config paths (in order of priority from highest to lowest):
 
-```/etc/ublue-update/ublue-update.toml```
+1. ```/etc/ublue-update/ublue-update.toml```
 
-```/usr/etc/ublue-update/ublue-update.toml```
+2. ```/usr/etc/ublue-update/ublue-update.toml```
 
 
 ## Config Variables
-Section: `checks`
+### Section: `checks`
 
-`min_battery_percent`: checks if battery is above specified percent
+* `min_battery_percent`: checks if battery is above specified percent
 
-`max_cpu_load_percent`: checks if cpu average load is under specified percent
+* `max_cpu_load_percent`: checks if cpu average load is under specified percent
 
-`max_mem_percent`: checks if memory usage is below specified the percent
+* `max_mem_percent`: checks if memory usage is below specified percent
 
+### Section: `notify`
 
-Section: `notify`
+* `dbus_notify`: enable graphical notifications via dbus
 
-`dbus_notify`: enable graphical notifications via dbus
+### Full Example
+
+```toml
+[checks]
+    min_battery_percent = 20.0  # Battery Level >= 20%?
+    max_cpu_load_percent = 50.0 #     CPU Usage <= 50%?
+    max_mem_percent = 90.0      #     RAM Usage <= 90%?
+[notify]
+    dbus_notify = false         # Do not show notifications
+```
 
 ## How do I build this?
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ See [`topgrade`](https://github.com/topgrade-rs/topgrade)'s GitHub for configuri
 
 * `network_not_metered`: if true, checks if the current network connection is not marked as metered
 
+### Section: `checks.scripts`
+
+In addition to the predefined checks above, it is also possible to implement
+custom conditions through user-provided scripts and their exit codes.
+Each entry in the `checks.scripts` array must specify the following settings:
+
+* `shell`: specifies the shell used to execute the custom script (e.g. `bash`)
+
+* `run`: specifies the script text to be run using the specified shell
+
+* `message`: an optional message that is shown when the check fails
+
+* `name`: an optional human-readable name for this check
+
+The custom script should use its exit code to indicate whether the updater should proceed
+(`exit code = 0`) or whether updates should be inhibited right now (any non-0 exit code).
+If `message` is not specified but the script has written text to `stdout`,
+that text will be used as the message.
+
 ### Section: `notify`
 
 * `dbus_notify`: enable graphical notifications via dbus
@@ -119,6 +138,35 @@ See [`topgrade`](https://github.com/topgrade-rs/topgrade)'s GitHub for configuri
     max_cpu_load_percent = 50.0 #     CPU Usage <= 50%?
     max_mem_percent = 90.0      #     RAM Usage <= 90%?
     network_not_metered = true  # Abort if network connection is metered
+
+    [[checks.scripts]]
+        name = "Example script that always fails"
+        shell = "bash"
+        run = "exit 1"
+        message = "Failure message - this message will always appear"
+
+    [[checks.scripts]]
+        name = "Example script that always succeeds"
+        shell = "bash"
+        run = "exit 0"
+        message = "Failure message - this message will never appear"
+
+    [[checks.scripts]]
+        name = "Example multiline script with custom message"
+        shell = "bash"
+        run = """
+echo "This is a custom message"
+exit 1
+"""
+
+    [[checks.scripts]]
+        name = "Python script"
+        shell = "python3"
+        run = """
+print("Python also works when installed")
+exit(1)
+"""
+
 [notify]
     dbus_notify = false         # Do not show notifications
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ options:
   -c, --check        run update checks and exit
   -u, --updatecheck  check for updates and exit
   -w, --wait         wait for transactions to complete and exit
+  --config CONFIG    use the specified config file
   --system           only run system updates (requires root)
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Each entry in the `checks.scripts` array must specify the following settings:
 
 * `name`: an optional human-readable name for this check
 
+The parameters `run` and `file` are mutually exclusive, but at least one must be specified.
+The `shell` parameter is mandatory when using `run`.
+
 The custom script should use its exit code to indicate whether the updater should proceed
 (`exit code = 0`) or whether updates should be inhibited right now (any non-0 exit code).
 If `message` is not specified but the script has written text to `stdout`,
@@ -166,6 +169,11 @@ exit 1
 print("Python also works when installed")
 exit(1)
 """
+
+    [[checks.scripts]]
+        name = "Example external script"
+        # shell = "bash" # specifying a shell is optional for external scripts/programs
+        file = "/bin/true"
 
 [notify]
     dbus_notify = false         # Do not show notifications

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ See [`topgrade`](https://github.com/topgrade-rs/topgrade)'s GitHub for configuri
 
 * `max_mem_percent`: checks if memory usage is below specified percent
 
+* `network_not_metered`: if true, checks if the current network connection is not marked as metered
+
 ### Section: `notify`
 
 * `dbus_notify`: enable graphical notifications via dbus
@@ -115,6 +117,7 @@ See [`topgrade`](https://github.com/topgrade-rs/topgrade)'s GitHub for configuri
     min_battery_percent = 20.0  # Battery Level >= 20%?
     max_cpu_load_percent = 50.0 #     CPU Usage <= 50%?
     max_mem_percent = 90.0      #     RAM Usage <= 90%?
+    network_not_metered = true  # Abort if network connection is metered
 [notify]
     dbus_notify = false         # Do not show notifications
 ```

--- a/files/usr/etc/ublue-update/ublue-update.toml
+++ b/files/usr/etc/ublue-update/ublue-update.toml
@@ -2,5 +2,6 @@
     min_battery_percent = 50.0
     max_cpu_load_percent = 50.0
     max_mem_percent = 90.0
+    network_not_metered = false
 [notify]
     dbus_notify = true

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -182,7 +182,7 @@ dbus_notify: bool = load_value("notify", "dbus_notify")
 # setup logging
 logging.basicConfig(
     format="[%(asctime)s] %(name)s:%(levelname)s | %(message)s",
-    level=os.getenv("UBLUE_LOG", default=logging.INFO),
+    level=os.getenv("UBLUE_LOG", default="INFO").upper(),
 )
 log = logging.getLogger(__name__)
 

--- a/src/ublue_update/config.py
+++ b/src/ublue_update/config.py
@@ -10,19 +10,12 @@ def load_config():
     ]
 
     # search for the right config
-    # BUG: config_path and fallback_config_path always have the same value
-    config_path = ""
-    fallback_config_path = ""
+    # first config file that is found wins
     for path in config_paths:
         if os.path.isfile(path):
-            if config_path == "":
-                config_path = path
-            fallback_config_path = path
-            break
+            return tomllib.load(open(path, "rb"))
 
-    fallback_config = tomllib.load(open(fallback_config_path, "rb"))
-    config = tomllib.load(open(config_path, "rb"))
-    return config, fallback_config
+    return config
 
 
 def safe_get_nested(dct, *keys):
@@ -35,7 +28,7 @@ def safe_get_nested(dct, *keys):
 
 
 def load_value(*keys):
-    return safe_get_nested(config, *keys) or safe_get_nested(fallback_config, *keys)
+    return safe_get_nested(config, *keys)
 
 
-config, fallback_config = load_config()
+config = load_config()

--- a/src/ublue_update/config.py
+++ b/src/ublue_update/config.py
@@ -10,6 +10,7 @@ def load_config():
     ]
 
     # search for the right config
+    # BUG: config_path and fallback_config_path always have the same value
     config_path = ""
     fallback_config_path = ""
     for path in config_paths:
@@ -24,11 +25,17 @@ def load_config():
     return config, fallback_config
 
 
-def load_value(key, value):
-    fallback = fallback_config[key][value]
-    if key in config.keys():
-        return config[key].get(value, fallback)
-    return fallback
+def safe_get_nested(dct, *keys):
+    for key in keys:
+        try:
+            dct = dct[key]
+        except KeyError:
+            return None
+    return dct
+
+
+def load_value(*keys):
+    return safe_get_nested(config, *keys) or safe_get_nested(fallback_config, *keys)
 
 
 config, fallback_config = load_config()

--- a/src/ublue_update/config.py
+++ b/src/ublue_update/config.py
@@ -38,6 +38,7 @@ class Config:
     min_battery_percent: Optional[float]
     max_cpu_load_percent: Optional[float]
     max_mem_percent: Optional[float]
+    custom_check_scripts: List[dict]
 
     def load_config(self, path=None):
         config_path = path or find_default_config_file()
@@ -51,6 +52,7 @@ class Config:
         self.min_battery_percent = load_value(config, "checks", "min_battery_percent")
         self.max_cpu_load_percent = load_value(config, "checks", "max_cpu_load_percent")
         self.max_mem_percent = load_value(config, "checks", "max_mem_percent")
+        self.custom_check_scripts = load_value(config, "checks", "scripts") or []
 
 
 cfg = Config()

--- a/src/ublue_update/update_inhibitors/custom.py
+++ b/src/ublue_update/update_inhibitors/custom.py
@@ -1,0 +1,68 @@
+import psutil
+import subprocess
+from typing import List, Optional
+from logging import getLogger
+from ublue_update.config import cfg
+
+"""Setup logging"""
+log = getLogger(__name__)
+
+
+def run_custom_check_script(script) -> dict:
+    if script.get('shell') != 'bash':
+        raise Exception('checks.scripts.*.shell must be set to \'bash\'')
+
+    log.debug(f"Running script {script}")
+
+    # Run the specified custom script via bash
+    script_result = subprocess.run(
+        ['bash', '-c', script['run']],
+        capture_output=True,
+        check=False,
+    )
+
+    # An exit code of 0 means "OK", a non-zero exit code
+    # means "Do not download or perform updates right now"
+    script_pass: bool = script_result.returncode == 0
+
+    # Use either the message specified in the config,
+    # the output of the script (if not empty), or a fallback
+    script_output: Optional[str] = script_result.stdout.strip()
+    if len(script_output) == 0:
+        script_output = None
+
+    # Write error messages to our log in case of failure
+    # to catch any interpreter errors etc.
+    script_stderr = script_result.stderr.strip()
+    if not script_pass and len(script_stderr) > 0:
+        log.warning(f"A custom check script failed and wrote the following to STDERR:\n====\n{script_stderr}\n====")
+
+    fallback_message = "A custom check script returned a non-0 exit code"
+    script_message = script.get('message') or script_output or fallback_message
+
+    return {
+        "passed": script_pass,
+        "message": script_message,
+    }
+
+
+def run_custom_check_scripts() -> List[dict]:
+    results = []
+    for script in (cfg.custom_check_scripts or []):
+        results.append(run_custom_check_script(script))
+    return results
+
+
+def check_custom_inhibitors() -> bool:
+
+    custom_inhibitors = run_custom_check_scripts()
+
+    failures = []
+    custom_checks_failed = False
+    for inhibitor_result in custom_inhibitors:
+        if not inhibitor_result["passed"]:
+            custom_checks_failed = True
+            failures.append(inhibitor_result["message"])
+    if not custom_checks_failed:
+        log.info("System passed custom checks")
+    return custom_checks_failed, failures

--- a/src/ublue_update/update_inhibitors/hardware.py
+++ b/src/ublue_update/update_inhibitors/hardware.py
@@ -1,10 +1,12 @@
 import psutil
+import subprocess
 from logging import getLogger
 from ublue_update.config import load_value
 
 """Setup logging"""
 log = getLogger(__name__)
 
+network_not_metered: bool = load_value("checks", "network_not_metered")
 min_battery_percent: float = load_value("checks", "min_battery_percent")
 max_cpu_load_percent: float = load_value("checks", "max_cpu_load_percent")
 max_mem_percent: float = load_value("checks", "max_mem_percent")
@@ -20,6 +22,37 @@ def check_network_status() -> dict:
                 network_up = True
                 break
     return {"passed": network_up, "message": "Network not enabled"}
+
+
+def check_network_not_metered() -> dict:
+    if not network_not_metered:
+        return {"passed": True, "message": "Network metering status is ignored"}
+    # Use busctl CLI to query the NetworkManager via D-Bus for
+    # the current metering status of the connection.
+    # The output on stdout will be "<datatype> <value>".
+    metered_status  = subprocess.run([
+            "busctl",
+            "get-property",
+            "org.freedesktop.NetworkManager",
+            "/org/freedesktop/NetworkManager",
+            "org.freedesktop.NetworkManager",
+            "Metered",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    # The possible values of "Metered" are documented here:
+    # https://networkmanager.dev/docs/api/latest/nm-dbus-types.html#NMMetered
+    #
+    #     NM_METERED_UNKNOWN   = 0 # The metered status is unknown
+    #     NM_METERED_YES       = 1 # Metered, the value was explicitly configured
+    #     NM_METERED_NO        = 2 # Not metered, the value was explicitly configured
+    #     NM_METERED_GUESS_YES = 3 # Metered, the value was guessed
+    #     NM_METERED_GUESS_NO  = 4 # Not metered, the value was guessed
+    #
+    is_network_metered = metered_status.strip() in ['u 1', 'u 3']
+    return {"passed": not is_network_metered, "message": "Network is metered"}
 
 
 def check_battery_status() -> dict:
@@ -59,6 +92,7 @@ def check_hardware_inhibitors() -> bool:
 
     hardware_inhibitors = [
         check_network_status(),
+        check_network_not_metered(),
         check_battery_status(),
         check_cpu_load(),
         check_mem_percentage(),

--- a/src/ublue_update/update_inhibitors/hardware.py
+++ b/src/ublue_update/update_inhibitors/hardware.py
@@ -2,15 +2,10 @@ import psutil
 import subprocess
 from typing import Optional
 from logging import getLogger
-from ublue_update.config import load_value
+from ublue_update.config import cfg
 
 """Setup logging"""
 log = getLogger(__name__)
-
-network_not_metered: Optional[bool] = load_value("checks", "network_not_metered")
-min_battery_percent: Optional[float] = load_value("checks", "min_battery_percent")
-max_cpu_load_percent: Optional[float] = load_value("checks", "max_cpu_load_percent")
-max_mem_percent: Optional[float] = load_value("checks", "max_mem_percent")
 
 
 def check_network_status() -> dict:
@@ -26,7 +21,7 @@ def check_network_status() -> dict:
 
 
 def check_network_not_metered() -> dict:
-    if not network_not_metered:
+    if not cfg.network_not_metered:
         return {
             "passed": True,
             "message": "Network metering status is ignored",
@@ -63,18 +58,18 @@ def check_network_not_metered() -> dict:
 
 
 def check_battery_status() -> dict:
-    if min_battery_percent:
+    if cfg.min_battery_percent:
         battery_status = psutil.sensors_battery()
         # null safety on the battery variable, it returns "None"
         # when the system doesn't have a battery
         battery_pass: bool = True
         if battery_status is not None:
             battery_pass = (
-                battery_status.percent >= min_battery_percent or battery_status.power_plugged
+                battery_status.percent >= cfg.min_battery_percent or battery_status.power_plugged
             )
         return {
             "passed": battery_pass,
-            "message": f"Battery less than {min_battery_percent}%",
+            "message": f"Battery less than {cfg.min_battery_percent}%",
         }
     else:
         return {
@@ -84,13 +79,13 @@ def check_battery_status() -> dict:
 
 
 def check_cpu_load() -> dict:
-    if max_cpu_load_percent:
+    if cfg.max_cpu_load_percent:
         # get load average percentage in last 5 minutes:
         # https://psutil.readthedocs.io/en/latest/index.html?highlight=getloadavg
         cpu_load_percent = psutil.getloadavg()[1] / psutil.cpu_count() * 100
         return {
-            "passed": cpu_load_percent < max_cpu_load_percent,
-            "message": f"CPU load is above {max_cpu_load_percent}%",
+            "passed": cpu_load_percent < cfg.max_cpu_load_percent,
+            "message": f"CPU load is above {cfg.max_cpu_load_percent}%",
         }
     else:
         return {
@@ -100,11 +95,11 @@ def check_cpu_load() -> dict:
 
 
 def check_mem_percentage() -> dict:
-    if max_mem_percent:
+    if cfg.max_mem_percent:
         mem = psutil.virtual_memory()
         return {
-            "passed": mem.percent < max_mem_percent,
-            "message": f"Memory usage is above {max_mem_percent}%",
+            "passed": mem.percent < cfg.max_mem_percent,
+            "message": f"Memory usage is above {cfg.max_mem_percent}%",
         }
     else:
         return {


### PR DESCRIPTION
This pull request contains four small-ish fixes/improvements:

* Improve the documentation clarity in the main README.md
* Allow specifying lowercase log levels via `UBLUE_LOG` to match the behavior of most other tools
* Cleanup the config file loading logic, and avoid crashes when not all config options are specified.
* Add a `--config` CLI option to allow alternate config files when testing

...as well as two new features related to the update precondition checks (these two were the main driver for this pull request):

* Add a `network_not_metered` check to prevent downloading multiple GB of data when on metered/mobile connections
(the latter of which happened to me while using my smartphone as a hotspot).
This check should probably be enabled in all environments where NetworkManager is supported, to avoid annoying surprises on mobile data plans. It is currently disabled by default, though, to not break any existing installations.

* Add a facility for using fully custom scripts to check for additional preconditions.
My personal rationale for this is that I want to be able to prevent unnecessary background work when using my laptop for a DJ set, to avoid stutter. I'm not sure yet whether I want to use a manual settings toggle or automatic detection of the DJ software for this, but implementing it in a flexible manner allows me and other to solve these usecases without bloating up the `ublue_update` code too much.

Fixes #115