### PR TITLE
fix: Remove confusing Notification regarding System updates

### DIFF
--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -102,10 +102,13 @@ def run_updates(system, system_update_available):
     transaction_wait()
 
     if process_uid == 0:
-        notify(
-            "System Updater",
-            "System passed checks, updating ...",
-        )
+        if system_update_available:
+            # Notify about a full system update but not about only
+            # distrobox and flatpak updates
+            notify(
+                "System Updater",
+                "System passed checks, updating ...",
+            )
         users = []
         try:
             users = get_active_sessions()


### PR DESCRIPTION
This commit removes the "System passed checks, updating ..." which is confusing as it will trigger every 6 hours even if there is no update available to install.

If there are other opinions on how to solve this, please let me know and I am happy to code something up.
I was just very confused the last days that my system "seemed" to update, but there were no system updates available.
Maybe there could be something done with the wording.