### PR TITLE
fix: use login1 dbus API, fix systemd-run

### DIFF
--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -41,7 +41,7 @@ def notify(title: str, body: str, actions: list = [], urgency: str = "normal"):
                 "/usr/bin/systemd-run",
                 "--user",
                 "--machine",
-                f"{user[1]}@", # magic number, corresponds to user name in ListUsers (see session.py)
+                f"{user[1]}@",  # magic number, corresponds to user name in ListUsers (see session.py)
                 "--pipe",
                 "--quiet",
             ]
@@ -134,7 +134,9 @@ def run_updates(system, system_update_available):
 
         """Users"""
         for user in users:
-            log.info(f"""Running update for user: '{user[1]}'""") # magic number, corresponds to username (see session.py)
+            log.info(
+                f"""Running update for user: '{user[1]}'"""
+            )  # magic number, corresponds to username (see session.py)
             out = subprocess.run(
                 [
                     "/usr/bin/systemd-run",

--- a/src/ublue_update/session.py
+++ b/src/ublue_update/session.py
@@ -2,14 +2,22 @@ import subprocess
 import json
 
 
-def get_active_sessions():
+def get_active_users():
     out = subprocess.run(
-        ["/usr/bin/loginctl", "list-sessions", "--output=json"],
+        [
+            "/usr/bin/busctl",
+            "--system",
+            "-j",
+            "call",
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "ListUsers",
+        ],
         capture_output=True,
     )
-    sessions = json.loads(out.stdout.decode("utf-8"))
-    active_sessions = []
-    for session in sessions:
-        if session.get("state") == "active":
-            active_sessions.append(session)
-    return active_sessions
+    # https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html
+    # ListUsers() returns an array of all currently logged in users. The structures in the array consist of the following fields: user id, user name, user object path.
+    users = json.loads(out.stdout.decode("utf-8"))
+    # sample output: {'type': 'a(uso)', 'data': [[[1000, 'user', '/org/freedesktop/login1/user/_1000']]]
+    return users["data"][0]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -47,7 +47,6 @@ def test_notify_uid_user(mock_run, mock_log, mock_os, mock_cfg):
         capture_output=True,
     )
 
-
 @patch("ublue_update.cli.cfg")
 def test_ask_for_updates_no_dbus_notify(mock_cfg):
     mock_cfg.dbus_notify = False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -162,7 +162,7 @@ def test_run_updates_user_no_system(
 
 
 @patch("ublue_update.cli.os")
-@patch("ublue_update.cli.get_active_sessions")
+@patch("ublue_update.cli.get_active_users")
 @patch("ublue_update.cli.acquire_lock")
 @patch("ublue_update.cli.transaction_wait")
 @patch("ublue_update.cli.subprocess.run")
@@ -211,7 +211,7 @@ def test_run_updates_system(
 
 
 @patch("ublue_update.cli.os")
-@patch("ublue_update.cli.get_active_sessions")
+@patch("ublue_update.cli.get_active_users")
 @patch("ublue_update.cli.acquire_lock")
 @patch("ublue_update.cli.transaction_wait")
 @patch("ublue_update.cli.subprocess.run")
@@ -254,7 +254,7 @@ def test_run_updates_without_image_update(
 
 
 @patch("ublue_update.cli.os")
-@patch("ublue_update.cli.get_active_sessions")
+@patch("ublue_update.cli.get_active_users")
 @patch("ublue_update.cli.acquire_lock")
 @patch("ublue_update.cli.transaction_wait")
 @patch("ublue_update.cli.subprocess.run")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -7,57 +7,37 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src"))
 )
 
-from ublue_update.session import get_active_sessions
+from ublue_update.session import get_active_users
 
-loginctl_json_output = b"""
-[
-        {
-                "session" : "3",
-                "uid" : 1001,
-                "user" : "test",
-                "seat" : null,
-                "leader" : 6205,
-                "class" : "manager",
-                "tty" : null,
-                "state": "active",
-                "idle" : false,
-                "since" : null
-        },
-        {
-                "session" : "c1",
-                "uid" : 1001,
-                "user" : "test",
-                "seat" : null,
-                "leader" : 6230,
-                "class" : "manager",
-                "tty" : null,
-                "state": "inactive",
-                "idle" : false,
-                "since" : null
-        }
-]
+busctl_json_output = b"""
+{'type': 'a(uso)', 'data': [[[1000, 'user', '/org/freedesktop/login1/user/_1000']]]
 """
 
 
 @patch("ublue_update.session.subprocess.run")
 def test_get_active_sessions(mock_run):
     mock_run.side_effect = [
-        MagicMock(stdout=loginctl_json_output),
+        MagicMock(stdout=busctl_json_output),
     ]
     assert get_active_sessions() == [
-        {
-            "session": "3",
-            "uid": 1001,
-            "user": "test",
-            "seat": None,
-            "leader": 6205,
-            "class": "manager",
-            "tty": None,
-            "state": "active",
-            "idle": False,
-            "since": None,
-        }
+        [
+            [
+                "1000",
+                "user",
+                "/org/freedesktop/login1/user/_1000",
+            ]
+        ]
     ]
     mock_run.assert_any_call(
-        ["/usr/bin/loginctl", "list-sessions", "--output=json"], capture_output=True
+        [
+            "/usr/bin/busctl",
+            "--system",
+            "-j",
+            "call",
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "ListUsers",
+        ],
+        capture_output=True,
     )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -9,23 +9,19 @@ sys.path.insert(
 
 from ublue_update.session import get_active_users
 
-busctl_json_output = b"""
-{'type': 'a(uso)', 'data': [[[1000, 'user', '/org/freedesktop/login1/user/_1000']]]
-"""
+busctl_json_output = b"""{"type":"a(uso)","data":[[[1000,"user","/org/freedesktop/login1/user/_1000"]]]}"""
 
 
 @patch("ublue_update.session.subprocess.run")
-def test_get_active_sessions(mock_run):
+def test_get_active_users(mock_run):
     mock_run.side_effect = [
         MagicMock(stdout=busctl_json_output),
     ]
-    assert get_active_sessions() == [
+    assert get_active_users() == [
         [
-            [
-                "1000",
-                "user",
-                "/org/freedesktop/login1/user/_1000",
-            ]
+            1000,
+            "user",
+            "/org/freedesktop/login1/user/_1000",
         ]
     ]
     mock_run.assert_any_call(

--- a/ublue-update.spec
+++ b/ublue-update.spec
@@ -29,7 +29,7 @@ BuildRequires: python-setuptools_scm
 BuildRequires: python-wheel
 Requires:      skopeo
 Requires:      libnotify
-Requires:      sudo
+Requires:      systemd
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-", ""); print(t)}
 


### PR DESCRIPTION
This PR supersedes: https://github.com/ublue-os/ublue-update/pull/133

`session.py` now uses the dbus API instead of using loginctl subprocess, instead using busctl as a subprocess, this can however be migrated to dbus-python easily. The dbus API is also hopefully more stable than the loginctl CLI, though we are still using busctl.

This also fixes an issue with update confirmation, where output wasn't probably being piped back into stdout when using `systemd-run`, meaning that update confirmations were impossible and `ublue-update` would error instead of update when confirming