### PR TITLE
feat: added much needed integration testing using containers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       tag: ${{ steps.release-please.outputs.tag_name }}
       upload_url: ${{ steps.release-please.outputs.upload_url }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release-please
         with:
           release-type: simple

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-39}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-41}"
 
 FROM registry.fedoraproject.org/fedora:${FEDORA_MAJOR_VERSION} AS builder
 
@@ -40,3 +40,5 @@ ENV UBLUE_ROOT=/app/output
 COPY --from=builder ${UBLUE_ROOT}/ublue-os/rpms /rpms
 # Copy dumped contents
 COPY --from=builder ${UBLUE_ROOT}/ublue-os/files /files
+
+

--- a/Containerfile.builder
+++ b/Containerfile.builder
@@ -1,3 +1,4 @@
+ARG FEDORA_VERSION="${FEDORA_VERSION:-41}"
 FROM registry.fedoraproject.org/fedora:latest AS builder
 
 ENV UBLUE_ROOT=/app/output

--- a/Containerfile.builder
+++ b/Containerfile.builder
@@ -24,4 +24,4 @@ RUN dnf install \
 
 FROM builder AS rpm
 
-RUN make build-rpm
+RUN just build-rpm

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -21,7 +21,7 @@ RUN dnf install \
     mkdir -p "$UBLUE_ROOT" && \
     rpkg spec --outdir  "$UBLUE_ROOT" && \
     dnf builddep -y output/ublue-update.spec && \
-    make build-rpm
+    just build-rpm
 
 # Dump a file list for each RPM for easier consumption
 RUN \
@@ -42,6 +42,46 @@ COPY --from=builder ${UBLUE_ROOT}/ublue-os/rpms /tmp/rpms
 RUN rpm-ostree install python3-pip
 RUN pip3 install --prefix /usr topgrade && rpm-ostree install /tmp/rpms/ublue-update.noarch.rpm
 
-RUN useradd -m -G wheel user && echo "user:" | chpasswd
+# FROM: https://github.com/containers/image_build/blob/main/podman/Containerfile, sets up podman to work in the container
+RUN useradd -G wheel podman && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid && \
+    echo "podman:" | chpasswd
+
+ADD ./containers.conf /etc/containers/containers.conf
+ADD ./podman-containers.conf /home/podman/.config/containers/containers.conf
+
+RUN mkdir -p /home/podman/.local/share/containers && \
+    chown podman:podman -R /home/podman && \
+    chmod 644 /etc/containers/containers.conf
+
+# Copy & modify the defaults to provide reference if runtime changes needed.
+# Changes here are required for running with fuse-overlay storage inside container.
+RUN sed -e 's|^#mount_program|mount_program|g' \
+           -e '/additionalimage.*/a "/var/lib/shared",' \
+           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+           /usr/share/containers/storage.conf \
+           > /etc/containers/storage.conf
+
+# Setup internal Podman to pass subscriptions down from host to internal container
+RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
+
+# Note VOLUME options must always happen after the chown call above
+# RUN commands can not modify existing volumes
+VOLUME /var/lib/containers
+VOLUME /home/podman/.local/share/containers
+
+RUN mkdir -p /var/lib/shared/overlay-images \
+             /var/lib/shared/overlay-layers \
+             /var/lib/shared/vfs-images \
+             /var/lib/shared/vfs-layers && \
+    touch /var/lib/shared/overlay-images/images.lock && \
+    touch /var/lib/shared/overlay-layers/layers.lock && \
+    touch /var/lib/shared/vfs-images/images.lock && \
+    touch /var/lib/shared/vfs-layers/layers.lock
+
+ENV _CONTAINERS_USERNS_CONFIGURED="" \
+    BUILDAH_ISOLATION=chroot
+# RUN useradd -m -G wheel user && echo "user:" | chpasswd
 
 CMD [ "/sbin/init" ]

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,0 +1,47 @@
+ARG TEST_IMAGE="${TEST_IMAGE:-ghcr.io/ublue-os/base-main:40}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
+
+FROM registry.fedoraproject.org/fedora:${FEDORA_MAJOR_VERSION} AS builder
+
+ENV UBLUE_ROOT=/app/output
+
+WORKDIR /app 
+
+ADD . /app
+
+RUN dnf install \
+    --disablerepo='*' \
+    --enablerepo='fedora,updates' \
+    --setopt install_weak_deps=0 \
+    --nodocs \
+    --assumeyes \
+    'dnf-command(builddep)' \
+    rpkg \
+    rpm-build && \
+    mkdir -p "$UBLUE_ROOT" && \
+    rpkg spec --outdir  "$UBLUE_ROOT" && \
+    dnf builddep -y output/ublue-update.spec && \
+    make build-rpm
+
+# Dump a file list for each RPM for easier consumption
+RUN \
+    for RPM in ${UBLUE_ROOT}/noarch/*.rpm; do \
+        NAME="$(rpm -q $RPM --queryformat='%{NAME}')"; \
+        mkdir -p "${UBLUE_ROOT}/ublue-os/files/${NAME}"; \
+        rpm2cpio "${RPM}" | cpio -idmv --directory "${UBLUE_ROOT}/ublue-os/files/${NAME}"; \
+        mkdir -p ${UBLUE_ROOT}/ublue-os/rpms/; \
+        cp "${RPM}" "${UBLUE_ROOT}/ublue-os/rpms/$(rpm -q "${RPM}" --queryformat='%{NAME}.%{ARCH}.rpm')"; \
+    done
+
+FROM ${TEST_IMAGE}
+
+ENV UBLUE_ROOT=/app/output
+
+
+COPY --from=builder ${UBLUE_ROOT}/ublue-os/rpms /tmp/rpms
+RUN rpm-ostree install python3-pip
+RUN pip3 install --prefix /usr topgrade && rpm-ostree install /tmp/rpms/ublue-update.noarch.rpm
+
+RUN useradd -m -G wheel user && echo "user:" | chpasswd
+
+CMD [ "/sbin/init" ]

--- a/containers.conf
+++ b/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,65 @@
+set shell := ["bash", "-c"]
+export UBLUE_ROOT := env_var_or_default("UBLUE_ROOT", "/app/output")
+export TARGET := "ublue-update"
+export SOURCE_DIR := UBLUE_ROOT + "/" + TARGET
+export RPMBUILD := UBLUE_ROOT + "/rpmbuild"
+
+export GITHUB_REF := env_var_or_default("GITHUB_REF","refs/tags/v1.0.0+" + `git rev-parse --short HEAD`)
+
+# Define the GITHUB_REF variable if it's not already set
+venv-create:
+	/usr/bin/python -m venv venv
+	source venv/bin/activate && pip3 install .
+	echo 'Enter: `source venv/bin/activate` to enter the venv'
+
+default:
+	just --list
+
+build:
+	black --check src
+	python3 -m build
+
+test:
+	pytest -v
+
+spec: output
+	rpkg spec --outdir "$PWD/output"
+
+build-rpm:
+	rpkg local --outdir "$PWD/output"
+
+output:
+	mkdir -p output
+
+format:
+	black src
+	flake8 src
+
+dnf-install:
+	dnf install -y "output/noarch/*.rpm"
+
+build-test:
+	podman build . -t testing -f Containerfile.test
+	podman run -it --security-opt label=disable --device /dev/fuse:rw --privileged testing
+#
+#builder-image:
+#	podman build -t "$TARGET:builder" -f Containerfile.builder .
+#
+#builder-exec:
+#	podman run --rm -it \
+#		-v "$PWD:$PWD" \
+#		-w "$PWD" \
+#		-e DISPLAY \
+#		-e DBUS_SESSION_BUS_ADDRESS \
+#		-e XDG_RUNTIME_DIR \
+#		--ipc host \
+#		-v "/tmp/.X11-unix:/tmp/.X11-unix" \
+#		-v /var/run/dbus:/var/run/dbus \
+#		-v /run/user/1000/bus:/run/user/1000/bus \
+#		-v /run/dbus:/run/dbus \
+#		-v "${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR}" \
+#		--security-opt label=disable \
+#		$TARGET:builder
+
+clean:
+	rm -rf "$UBLUE_ROOT"

--- a/podman-containers.conf
+++ b/podman-containers.conf
@@ -1,0 +1,5 @@
+[containers]
+volumes = [
+	"/proc:/proc",
+]
+default_sysctls = []

--- a/src/ublue_update/cli.py
+++ b/src/ublue_update/cli.py
@@ -67,7 +67,7 @@ def ask_for_updates(system):
         return
     # if the user has confirmed
     if "universal-blue-update-confirm" in out.stdout.decode("utf-8"):
-        run_updates(system, True)
+        run_updates(system, True, False)
 
 
 def inhibitor_checks_failed(
@@ -83,7 +83,7 @@ def inhibitor_checks_failed(
     raise Exception(f"update failed to pass checks: \n - {exception_log}")
 
 
-def run_updates(system, system_update_available):
+def run_updates(system, system_update_available, dry_run):
     process_uid = os.getuid()
     filelock_path = "/run/ublue-update.lock"
     if process_uid != 0:
@@ -95,7 +95,25 @@ def run_updates(system, system_update_available):
         raise Exception("updates are already running for this user")
 
     """Wait on any existing transactions to complete before updating"""
-    transaction_wait()
+    # remove backwards compat warnings in topgrade (requires user confirmation without this env var)
+    os.environ["TOPGRADE_SKIP_BRKC_NOTIFY"] = "true"
+    topgrade_args = [
+        "/usr/bin/topgrade",
+    ]
+
+    if dry_run:
+        topgrade_args.append("--dry-run")
+    else:
+        transaction_wait()
+
+    topgrade_system = topgrade_args + [
+        "--config",
+        "/usr/share/ublue-update/topgrade-system.toml",
+    ]
+    topgrade_user = topgrade_args + [
+        "--config",
+        "/usr/share/ublue-update/topgrade-user.toml",
+    ]
 
     if process_uid == 0:
         if system_update_available:
@@ -115,14 +133,8 @@ def run_updates(system, system_update_available):
             users = []
 
         """System"""
-        # remove backwards compat warnings in topgrade (requires user confirmation without this env var)
-        os.environ["TOPGRADE_SKIP_BRKC_NOTIFY"] = "true"
         out = subprocess.run(
-            [
-                "/usr/bin/topgrade",
-                "--config",
-                "/usr/share/ublue-update/topgrade-system.toml",
-            ],
+            topgrade_system,
             capture_output=True,
         )
         log.debug(out.stdout.decode("utf-8"))
@@ -137,19 +149,19 @@ def run_updates(system, system_update_available):
             log.info(
                 f"""Running update for user: '{user[1]}'"""
             )  # magic number, corresponds to username (see session.py)
+
+            args = [
+                "/usr/bin/systemd-run",
+                "--setenv=TOPGRADE_SKIP_BRKC_NOTIFY=true",
+                "--user",
+                "--machine",
+                f"{user[1]}@",
+                "--pipe",
+                "--quiet",
+            ] + topgrade_user
+
             out = subprocess.run(
-                [
-                    "/usr/bin/systemd-run",
-                    "--setenv=TOPGRADE_SKIP_BRKC_NOTIFY=true",
-                    "--user",
-                    "--machine",
-                    f"{user[1]}@",
-                    "--pipe",
-                    "--quiet",
-                    "/usr/bin/topgrade",
-                    "--config",
-                    "/usr/share/ublue-update/topgrade-user.toml",
-                ],
+                args,
                 capture_output=True,
             )
             log.debug(out.stdout.decode("utf-8"))
@@ -189,8 +201,14 @@ def main():
         action="store_true",
         help="force manual update, skipping update checks",
     )
+    parser.add_argument("--config", help="use the specified config file")
     parser.add_argument(
-        "-c", "--check", action="store_true", help="run update checks and exit"
+        "--system",
+        action="store_true",
+        help="only run system updates (requires root)",
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="run update checks and exit"
     )
     parser.add_argument(
         "-u",
@@ -204,16 +222,21 @@ def main():
         action="store_true",
         help="wait for transactions to complete and exit",
     )
-    parser.add_argument("--config", help="use the specified config file")
     parser.add_argument(
-        "--system",
+        "--dry-run",
         action="store_true",
-        help="only run system updates (requires root)",
+        help="dry run ublue-update",
     )
     cli_args = parser.parse_args()
 
     # Load the configuration file
+
     cfg.load_config(cli_args.config)
+
+    if cli_args.dry_run:
+        # run system updates
+        run_updates(False, True, True)
+        os._exit(0)
 
     if cli_args.wait:
         transaction_wait()
@@ -245,7 +268,7 @@ def main():
     # system checks passed
     log.info("System passed all update checks")
     try:
-        run_updates(cli_args.system, system_update_available)
+        run_updates(cli_args.system, system_update_available, False)
     except Exception as e:
         log.info(f"Failed to update: {e}")
         os._exit(1)

--- a/src/ublue_update/session.py
+++ b/src/ublue_update/session.py
@@ -21,5 +21,3 @@ def get_active_users():
     users = json.loads(out.stdout.decode("utf-8"))
     # sample output: {'type': 'a(uso)', 'data': [[[1000, 'user', '/org/freedesktop/login1/user/_1000']]]
     return users["data"][0]
-
-print(get_active_users())

--- a/src/ublue_update/session.py
+++ b/src/ublue_update/session.py
@@ -21,3 +21,5 @@ def get_active_users():
     users = json.loads(out.stdout.decode("utf-8"))
     # sample output: {'type': 'a(uso)', 'data': [[[1000, 'user', '/org/freedesktop/login1/user/_1000']]]
     return users["data"][0]
+
+print(get_active_users())

--- a/ublue-update.spec
+++ b/ublue-update.spec
@@ -15,7 +15,7 @@ Source:        {{{ git_dir_pack }}}
 
 BuildArch:     noarch
 Supplements:   rpm-ostree flatpak
-BuildRequires: make
+BuildRequires: just
 BuildRequires: systemd-rpm-macros
 BuildRequires: black
 BuildRequires: python-flake8


### PR DESCRIPTION
This PR does a couple things at the moment:
- Sunset the old `Containerfile` and `Containerfile.builder` in favor a Container file that does integration testing
- Move away from the Makefile to use just (we are not using C, justfiles are much more well suited as a task runner)
- add a new option (--dry-run) to the `ublue-update` CLI to allow running updates as a "dry-run" for testing on the container (not everything works just yet)
- Renovate the release-please action to actually function